### PR TITLE
Create `CatsResource`

### DIFF
--- a/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
@@ -14,8 +14,10 @@ trait CatsResource[T](using ioRuntime: IORuntime = IORuntime.global) extends Spe
 
   def resource: Resource[IO, T]
 
-  protected def acquire: Future[T] = resource.allocated.flatMap { (t, close) =>
-    finalizer.complete(close).as(t)
-  }.unsafeToFuture()(ioRuntime)
-  
+  protected def acquire: Future[T] = resource.allocated
+    .flatMap { (t, close) =>
+      finalizer.complete(close).as(t)
+    }
+    .unsafeToFuture()(ioRuntime)
+
   protected def release(resource: T): Execution = finalizer.get.flatten

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
@@ -1,0 +1,21 @@
+package org.specs2.cats.effect
+
+import cats.effect.Deferred
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.unsafe.IORuntime
+import org.specs2.specification.core.Execution
+import org.specs2.specification.Resource as SpecsResource
+
+import scala.concurrent.Future
+
+trait CatsResource[T](using ioRuntime: IORuntime = IORuntime.global) extends SpecsResource[T], IOExecution:
+  private val finalizer = Deferred.unsafe[IO, IO[Unit]]
+
+  def resource: Resource[IO, T]
+
+  protected def acquire: Future[T] = resource.allocated.flatMap { (t, close) =>
+    finalizer.complete(close).as(t)
+  }.unsafeToFuture()(ioRuntime)
+  
+  protected def release(resource: T): Execution = finalizer.get.flatten

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResource.scala
@@ -4,6 +4,7 @@ import cats.effect.Deferred
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.unsafe.IORuntime
+import cats.syntax.all.*
 import org.specs2.specification.core.Execution
 import org.specs2.specification.Resource as SpecsResource
 
@@ -14,10 +15,11 @@ trait CatsResource[T](using ioRuntime: IORuntime = IORuntime.global) extends Spe
 
   def resource: Resource[IO, T]
 
-  protected def acquire: Future[T] = resource.allocated
+  protected def acquire: Future[T] = resource.attempt.allocated
     .flatMap { (t, close) =>
       finalizer.complete(close).as(t)
     }
+    .rethrow
     .unsafeToFuture()(ioRuntime)
 
   protected def release(resource: T): Execution = finalizer.get.flatten

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResourceExecution.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/CatsResourceExecution.scala
@@ -1,0 +1,13 @@
+package org.specs2.cats.effect
+
+import cats.effect.MonadCancelThrow
+import cats.effect.Resource
+import cats.syntax.all.*
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.AsExecution
+import org.specs2.specification.core.Execution
+
+trait CatsResourceExecution:
+  given [F[_]: MonadCancelThrow, T](using exec: AsExecution[F[T]]): AsExecution[Resource[F, T]] with
+    def execute(r: =>Resource[F, T]): Execution =
+      exec.execute(r.use(_.pure))

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/IOExecution.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/IOExecution.scala
@@ -1,4 +1,4 @@
-package org.specs2.matcher
+package org.specs2.cats.effect
 
 import cats.effect.*
 import org.specs2.execute.*

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/IOMatchers.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/IOMatchers.scala
@@ -17,12 +17,10 @@ import scala.concurrent.Future
 
 /** Matchers for `IO`. These will run asynchronously on the (overridable) `IORuntime`.
   */
-trait IOMatchers extends ValueChecks:
-
-  given executionEnv: ExecutionEnv =
-    ExecutionEnv.fromGlobalExecutionContext
-
-  given ioRuntime: IORuntime = IORuntime.global
+trait IOMatchers(using
+    executionEnv: ExecutionEnv = ExecutionEnv.fromGlobalExecutionContext,
+    ioRuntime: IORuntime = IORuntime.global
+) extends ValueChecks:
 
   extension [A](ioa: IO[A])
     private def unsafeFoldOutcome[B](canceled: =>B, errored: Throwable => B, completed: A => B): Future[B] =

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/IOMatchers.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/IOMatchers.scala
@@ -1,14 +1,16 @@
-package org.specs2
-package matcher
+package org.specs2.cats.effect
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import cats.syntax.all.*
 import org.specs2.concurrent.ExecutionEnv
+import org.specs2.execute.Error
 import org.specs2.execute.Failure
 import org.specs2.execute.Result
-import org.specs2.execute.Error
 import org.specs2.execute.Success
+import org.specs2.matcher.FutureMatcher
+import org.specs2.matcher.ValueCheck
+import org.specs2.matcher.ValueChecks
 import org.specs2.text.Regexes.matchesSafely
 
 import scala.concurrent.Future

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/SyncIOExecution.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/SyncIOExecution.scala
@@ -1,4 +1,4 @@
-package org.specs2.matcher
+package org.specs2.cats.effect
 
 import cats.effect.SyncIO
 import org.specs2.execute.AsResult

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/SyncIOMatchers.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/SyncIOMatchers.scala
@@ -1,11 +1,13 @@
-package org.specs2
-package matcher
+package org.specs2.cats.effect
 
 import cats.effect.SyncIO
-import execute.ResultImplicits.*
-import org.specs2.execute.Result
 import org.specs2.execute.Error
 import org.specs2.execute.Failure
+import org.specs2.execute.Result
+import org.specs2.execute.ResultImplicits.*
+import org.specs2.matcher.Matcher
+import org.specs2.matcher.ValueCheck
+import org.specs2.matcher.ValueChecks
 
 import scala.reflect.ClassTag
 

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
@@ -1,0 +1,53 @@
+package org.specs2.cats.effect
+
+import cats.effect.IO
+import cats.effect.Ref
+import org.specs2.Specification
+import cats.effect.Resource
+
+trait LocalCatsResourceSpec extends Specification, IOExecution, CatsResource[(Int, Int)]:
+  import LocalCatsResourceSpec.*
+
+  val localCounter = Ref.unsafe[IO, Int](0)
+  val released = Ref.unsafe[IO, Boolean](false)
+
+  def resource: Resource[IO, (Int, Int)] = Resource.eval(localCounter.getAndUpdate(_ + 1).product(globalCounter.getAndUpdate(_ + 1))).onFinalize(released.set(true))
+
+  def is = s2"""
+    The resource is re-acquired per-spec: ${}
+  """
+
+  def reacquired = { (i: Int) =>
+    specCounter.getAndUpdate(_ + 1).map(i === _)
+  }
+
+object LocalCatsResourceSpec:
+  val globalCounter = Ref.unsafe[IO, Int](0)
+  val specCounter = Ref.unsafe[IO, Int](0)
+
+trait GlobalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Int]:
+  import GlobalCatsResourceSpec.*
+
+  final override def resourceKey = Some("global")
+
+  def resource: Resource[IO, Int] = Resource.eval(counter.getAndUpdate(_ + 1)).onFinalize(released.set(true))
+
+  def is = s2"""
+    The resource has been acquired exactly once: $acquired
+    The resource has not been prematurely released: $notReleased
+  """
+
+  def acquired = { (i: Int) =>
+    i === 0
+  }
+
+  def notReleased = released.get must beSuccess(false)
+
+
+object GlobalCatsResourceSpec:
+  val counter = Ref.unsafe[IO, Int](0)
+  val released = Ref.unsafe[IO, Boolean](false)
+
+class GlobalCatsResource1Spec extends GlobalCatsResourceSpec
+class GlobalCatsResource2Spec extends GlobalCatsResourceSpec
+class GlobalCatsResource3Spec extends GlobalCatsResourceSpec

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
@@ -23,11 +23,11 @@ trait LocalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Ref[
   """
 
   def reacquired = { (ref: Ref[IO, Int]) =>
-    ref.getAndUpdate(_ + 1) === 0
+    ref.getAndUpdate(_ + 1) must beSuccess(0)
   }
 
   def shared = { (ref: Ref[IO, Int]) =>
-    ref.getAndUpdate(_ + 1) === 1
+    ref.getAndUpdate(_ + 1) must beSuccess(1)
   }
 
   def notReleased = released.get must beSuccess(false)

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
@@ -6,7 +6,7 @@ import cats.effect.Resource
 import org.specs2.Specification
 import org.specs2.execute.Result
 
-trait LocalCatsResourceSpec extends Specification, IOExecution, IOMatchers, CatsResource[Ref[IO, Int]]:
+trait LocalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Ref[IO, Int]]:
 
   sequential
 
@@ -23,11 +23,11 @@ trait LocalCatsResourceSpec extends Specification, IOExecution, IOMatchers, Cats
   """
 
   def reacquired = { (ref: Ref[IO, Int]) =>
-    ref.getAndUpdate(_ + 1).map(_ === 0)
+    ref.getAndUpdate(_ + 1) === 0
   }
 
   def shared = { (ref: Ref[IO, Int]) =>
-    ref.getAndUpdate(_ + 1).map(_ === 1)
+    ref.getAndUpdate(_ + 1) === 1
   }
 
   def notReleased = released.get must beSuccess(false)

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
@@ -2,28 +2,44 @@ package org.specs2.cats.effect
 
 import cats.effect.IO
 import cats.effect.Ref
-import org.specs2.Specification
 import cats.effect.Resource
+import org.specs2.Specification
+import org.specs2.execute.Result
 
-trait LocalCatsResourceSpec extends Specification, IOExecution, CatsResource[(Int, Int)]:
+trait LocalCatsResourceSpec extends Specification, IOExecution, IOMatchers, CatsResource[(Int, Int)]:
   import LocalCatsResourceSpec.*
 
   val localCounter = Ref.unsafe[IO, Int](0)
   val released = Ref.unsafe[IO, Boolean](false)
 
-  def resource: Resource[IO, (Int, Int)] = Resource.eval(localCounter.getAndUpdate(_ + 1).product(globalCounter.getAndUpdate(_ + 1))).onFinalize(released.set(true))
+  def resource: Resource[IO, (Int, Int)] = Resource
+    .eval(localCounter.getAndUpdate(_ + 1).product(globalCounter.getAndUpdate(_ + 1)))
+    .onFinalize(released.set(true))
 
   def is = s2"""
-    The resource is re-acquired per-spec: ${}
+    The resource is re-acquired per-spec $reacquired
+    The resource is shared in the spec $shared
+    The resource is shared in the spec $shared
+    The resource is not prematurely released $notReleased
   """
 
-  def reacquired = { (i: Int) =>
-    specCounter.getAndUpdate(_ + 1).map(i === _)
+  def reacquired: ((Int, Int)) => IO[Result] = { (_, globalCount) =>
+    specCounter.getAndUpdate(_ + 1).map(globalCount === _)
   }
+
+  def shared: ((Int, Int)) => Result = { (resource, _) =>
+    resource === 0
+  }
+
+  def notReleased = released.get must beSuccess(false)
 
 object LocalCatsResourceSpec:
   val globalCounter = Ref.unsafe[IO, Int](0)
   val specCounter = Ref.unsafe[IO, Int](0)
+
+class LocalCatsResource1Spec extends LocalCatsResourceSpec
+
+class LocalCatsResource2Spec extends LocalCatsResourceSpec
 
 trait GlobalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Int]:
   import GlobalCatsResourceSpec.*
@@ -33,8 +49,8 @@ trait GlobalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Int
   def resource: Resource[IO, Int] = Resource.eval(counter.getAndUpdate(_ + 1)).onFinalize(released.set(true))
 
   def is = s2"""
-    The resource has been acquired exactly once: $acquired
-    The resource has not been prematurely released: $notReleased
+    The resource has been acquired exactly once $acquired
+    The resource is not prematurely released $notReleased
   """
 
   def acquired = { (i: Int) =>
@@ -42,7 +58,6 @@ trait GlobalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Int
   }
 
   def notReleased = released.get must beSuccess(false)
-
 
 object GlobalCatsResourceSpec:
   val counter = Ref.unsafe[IO, Int](0)

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/CatsResourceSpec.scala
@@ -8,15 +8,13 @@ import org.specs2.execute.Result
 
 trait LocalCatsResourceSpec extends Specification, IOMatchers, CatsResource[Ref[IO, Int]]:
 
-  sequential
-
   val released = Ref.unsafe[IO, Boolean](false)
 
   def resource: Resource[IO, Ref[IO, Int]] = Resource
     .eval(IO.ref(0))
     .onFinalize(released.set(true))
 
-  def is = s2"""
+  def is = sequential ^ s2"""
     The resource is re-acquired per-spec $reacquired
     The resource is shared in the spec $shared
     The resource is not prematurely released $notReleased

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/IOMatchersSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/IOMatchersSpec.scala
@@ -1,8 +1,9 @@
-package org.specs2
-package matcher
+package org.specs2.cats.effect
 
 import cats.effect.*
+import org.specs2.Specification
 import org.specs2.concurrent.*
+
 import scala.concurrent.duration.*
 
 class IOMatchersSpec extends Specification with IOMatchers with IOExecution:

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/SyncIOMatchersSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/SyncIOMatchersSpec.scala
@@ -1,8 +1,9 @@
-package org.specs2
-package matcher
+package org.specs2.cats.effect
 
 import cats.effect.*
+import org.specs2.Specification
 import org.specs2.concurrent.*
+
 import scala.concurrent.duration.*
 
 class SyncIOMatchersSpec extends Specification with SyncIOMatchers with SyncIOExecution:

--- a/cats/src/main/scala/org/specs2/cats/NonEmptyMatchers.scala
+++ b/cats/src/main/scala/org/specs2/cats/NonEmptyMatchers.scala
@@ -1,4 +1,4 @@
-package org.specs2.matcher
+package org.specs2.cats
 
 import cats.data.*
 import org.specs2.collection.*

--- a/cats/src/main/scala/org/specs2/cats/ValidatedMatchers.scala
+++ b/cats/src/main/scala/org/specs2/cats/ValidatedMatchers.scala
@@ -1,7 +1,9 @@
-package org.specs2.matcher
+package org.specs2.cats
 
 import cats.data.Validated
-import scala.language.adhocExtensions
+import org.specs2.matcher.OptionLikeCheckedMatcher
+import org.specs2.matcher.OptionLikeMatcher
+import org.specs2.matcher.ValueCheck
 
 /** Matchers for the Validated datatype
   */

--- a/cats/src/test/scala/org/specs2/cats/NonEmptyMatchersSpec.scala
+++ b/cats/src/test/scala/org/specs2/cats/NonEmptyMatchersSpec.scala
@@ -1,7 +1,7 @@
-package org.specs2
-package matcher
+package org.specs2.cats
 
 import cats.data.*
+import org.specs2.Specification
 
 class NonEmptyMatchersSpec extends Specification with NonEmptyMatchers:
   def is = s2"""

--- a/cats/src/test/scala/org/specs2/cats/ValidatedMatchersSpec.scala
+++ b/cats/src/test/scala/org/specs2/cats/ValidatedMatchersSpec.scala
@@ -1,8 +1,9 @@
-package org.specs2
-package matcher
+package org.specs2.cats
 
 import cats.data.Validated
-import cats.data.Validated.{Invalid, Valid}
+import cats.data.Validated.Invalid
+import cats.data.Validated.Valid
+import org.specs2.Specification
 
 class ValidatedMatchersSpec extends Specification with ValidatedMatchers:
   def is = s2"""


### PR DESCRIPTION
Closes #6. Thanks for all of your help with `Resource`!

I also did some package re-organizing into `org.specs2.cats[.effect]` since this is not just matchers, what do you think?