### PR TITLE
scalacheck-effect module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val scalacheckEffect = crossProject(platforms: _*)
   )
   .jvmSettings(buildJvmSettings)
   .jsSettings(buildJsSettings)
+  .dependsOn(catsEffect % Test)
 
 /** SETTINGS */
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,9 @@ lazy val specs2Cats = project
     cats.jvm,
     cats.js,
     catsEffect.jvm,
-    catsEffect.js
+    catsEffect.js,
+    scalacheckEffect.jvm,
+    scalacheckEffect.js
   )
 
 val platforms = List(JVMPlatform, JSPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -43,17 +43,36 @@ lazy val catsEffect = crossProject(platforms: _*)
   .jsSettings(buildJsSettings)
   .dependsOn(cats)
 
+lazy val scalacheckEffect = crossProject(platforms: _*)
+  .crossType(CrossType.Pure)
+  .withoutSuffixFor(jvm)
+  .in(file("scalacheck-effect"))
+  .settings(
+    organization := "org.specs2",
+    name := "specs2-scalacheck-effect",
+    scalacheckEffectDependencies,
+    buildSettings
+  )
+  .jvmSettings(buildJvmSettings)
+  .jsSettings(buildJsSettings)
+
 /** SETTINGS */
 
 val Scala3 = "3.1.0"
 ThisBuild / crossScalaVersions := Seq(Scala3)
 ThisBuild / scalaVersion := Scala3
 
+val Specs2Version = "5.0.0-RC-21"
+
 val catsDependencies = libraryDependencies ++= Seq(
-  "org.specs2" %%% "specs2-core" % "5.0.0-RC-21",
+  "org.specs2" %%% "specs2-core" % Specs2Version,
   "org.typelevel" %%% "cats-core" % "2.6.1"
 )
 val catsEffectDependencies = libraryDependencies += "org.typelevel" %%% "cats-effect" % "3.2.9"
+val scalacheckEffectDependencies = libraryDependencies ++= Seq(
+  "org.specs2" %%% "specs2-scalacheck" % Specs2Version,
+  "org.typelevel" %%% "scalacheck-effect" % "1.0.3"
+)
 
 lazy val rootSettings =
   compilationSettings ++

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/AsResultPropF.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/AsResultPropF.scala
@@ -1,0 +1,71 @@
+package org.specs2
+package scalacheck
+package effect
+
+import cats.MonadThrow
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.effect.PropF
+import org.scalacheck.util.*
+import org.specs2.specification.core.AsExecution
+import org.specs2.specification.core.Execution
+
+import scala.annotation.tailrec
+
+import execute.*
+
+/** Implicits to convert PropF to AsResult and AsResult to PropF
+  */
+trait AsResultPropF extends ScalaCheckEffectPropertyCheck with AsResultPropFLowImplicits:
+
+  given asResultToPropF[F[_]: MonadThrow, R: AsResult]: Conversion[R, PropF[F]] with
+    def apply(r: R): PropF[F] =
+      r.asInstanceOf[Matchable] match
+        case p: PropF[F] @unchecked => p
+        case _ =>
+          lazy val result = ResultExecution.execute(AsResult(r))
+
+          @tailrec
+          def resultToProp(r: execute.Result): PropF[F] =
+            r match
+              case f: execute.Failure => PropF.exception(new FailureException(f))
+              case s: execute.Skipped => PropF.exception(new SkipException(s))
+              case p: execute.Pending => PropF.exception(new PendingException(p))
+              case e: execute.Error   => PropF.exception(e.exception)
+
+              case execute.DecoratedResult(_, r1) =>
+                // display the datatables on a new line
+                resultToProp(r1.updateMessage("\n" + _))
+
+              case other => PropF.passed
+
+          val prop = resultToProp(result)
+
+          prop
+
+  /** implicit typeclass instance to create examples from a Prop */
+  given propFAsExecution[F[_]: MonadThrow](using p: Parameters, pfq: FreqMap[Set[Any]] => Pretty)(using
+      exec: AsExecution[F[Result]]
+  ): AsExecution[PropF[F]] with
+    def execute(propF: =>PropF[F]): Execution =
+      check(propF, p, pfq)
+
+trait AsResultPropFLowImplicits extends ScalaCheckEffectPropertyCheck with ScalaCheckParameters:
+
+  given scalaCheckPropertyAsExecution[F[_]: MonadThrow, S <: ScalaCheckEffectProperty[F]](using
+      exec: AsExecution[F[Result]]
+  ): AsExecution[S] with
+    def execute(prop: =>S): Execution =
+      try
+        lazy val p = prop
+        check(p.propF, p.parameters, p.prettyFreqMap)
+      catch
+        // this is necessary in case of thrown expectations inside the property
+        case FailureException(f) =>
+          f
+
+        case t: Throwable =>
+          AsResultPropF.propFAsExecution.execute(PropF.exception(t))
+
+object AsResultPropF extends AsResultPropF

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffect.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffect.scala
@@ -1,0 +1,10 @@
+package org.specs2.scalacheck
+package effect
+
+trait ScalaCheckEffect
+    extends ScalaCheckEffectPropertyCreation
+    with ScalaCheckEffectPropertyCheck
+    with ScalaCheckParameters
+    with AsResultPropF
+    with ScalaCheckEffectPropertyDsl
+    with GenInstances

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
@@ -105,7 +105,7 @@ object ScalaCheckEffectProperty:
       case Some(s) => PropF.forAllShrinkF(a.arbitrary, s.shrink)(f)
       case _       => PropF.forAllNoShrinkF(f)
 
-/** A ScalaCheckFunction adds the possibility to select various typeclass instances for a given property:
+/** A ScalaCheckEffectFunction adds the possibility to select various typeclass instances for a given property:
   *
   *   - Arbitrary to generate values
   *   - Shrink to shrink counter-examples
@@ -282,6 +282,1085 @@ case class ScalaCheckEffectFunction2[F[_]: MonadThrow, T1, T2, R](
 
   def prepare(action: (T1, T2) => (T1, T2)): SelfType =
     copy(execute = (t1: T1, t2: T2) => execute.tupled(action(t1, t2)))
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction3[F[_]: MonadThrow, T1, T2, T3, R](
+    execute: (T1, T2, T3) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction3[F, T1, T2, T3, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3) => {
+    lazy val executed = execute(t1, t2, t3)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) => makePropF((t3: T3) => propFunction(t1, t2, t3), argInstances3.shrink, parameters),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitraries(a1: Arbitrary[T1], a2: Arbitrary[T2], a3: Arbitrary[T3]): SelfType =
+    setArbitrary1(a1).setArbitrary2(a2).setArbitrary3(a3)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3]): SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrinks(s1: Shrink[T1], s2: Shrink[T2], s3: Shrink[T3]): SelfType =
+    setShrink1(s1).setShrink2(s2).setShrink3(s3)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+
+  def setPretties(p1: T1 => Pretty, p2: T2 => Pretty, p3: T3 => Pretty): SelfType =
+    setPretty1(p1).setPretty2(p2).setPretty3(p3)
+  def pretties(p1: T1 => String, p2: T2 => String, p3: T3 => String): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collectAllArgs(f1: T1 => Any, f2: T2 => Any, f3: T3 => Any): SelfType =
+    collectArg1(f1).collectArg2(f2).collectArg3(f3)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3
+
+  def prepare(action: (T1, T2, T3) => (T1, T2, T3)): SelfType =
+    copy(execute = (t1: T1, t2: T2, t3: T3) => execute.tupled(action(t1, t2, t3)))
+
+  def setContext(context: Context): SelfType = copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction4[F[_]: MonadThrow, T1, T2, T3, T4, R](
+    execute: (T1, T2, T3, T4) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    argInstances4: ScalaCheckArgInstances[T4],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction4[F, T1, T2, T3, T4, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given Arbitrary[T4] = argInstances4.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+  private given (T4 => Pretty) = argInstances4.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3, t4: T4) => {
+    lazy val executed = execute(t1, t2, t3, t4)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) =>
+            makePropF(
+              (t3: T3) => makePropF((t4: T4) => propFunction(t1, t2, t3, t4), argInstances4.shrink, parameters),
+              argInstances3.shrink,
+              parameters
+            ),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None),
+    argInstances4 = argInstances4.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitrary4(a4: Arbitrary[T4]): SelfType = copy(argInstances4 = argInstances4.copy(arbitrary = a4))
+  def setArbitraries(a1: Arbitrary[T1], a2: Arbitrary[T2], a3: Arbitrary[T3], a4: Arbitrary[T4]): SelfType =
+    setArbitrary1(a1).setArbitrary2(a2).setArbitrary3(a3).setArbitrary4(a4)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGen4(g4: Gen[T4]): SelfType = setArbitrary4(Arbitrary(g4))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4]): SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3).setGen4(g4)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrink4(s4: Shrink[T4]): SelfType = copy(argInstances4 = argInstances4.copy(shrink = Some(s4)))
+  def setShrinks(s1: Shrink[T1], s2: Shrink[T2], s3: Shrink[T3], s4: Shrink[T4]): SelfType =
+    setShrink1(s1).setShrink2(s2).setShrink3(s3).setShrink4(s4)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def setPretty4(p4: T4 => Pretty): SelfType = copy(argInstances4 = argInstances4.copy(pretty = p4))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+  def pretty4(p4: T4 => String): SelfType = setPretty4((t4: T4) => Pretty(_ => p4(t4)))
+
+  def setPretties(p1: T1 => Pretty, p2: T2 => Pretty, p3: T3 => Pretty, p4: T4 => Pretty): SelfType =
+    setPretty1(p1).setPretty2(p2).setPretty3(p3).setPretty4(p4)
+  def pretties(p1: T1 => String, p2: T2 => String, p3: T3 => String, p4: T4 => String): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3).pretty4(p4)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collectArg4(f: T4 => Any): SelfType =
+    copy(argInstances4 = argInstances4.copy(collectors = argInstances4.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collect4: SelfType = collectArg4(_.toString)
+  def collectAllArgs(f1: T1 => Any, f2: T2 => Any, f3: T3 => Any, f4: T4 => Any): SelfType =
+    collectArg1(f1).collectArg2(f2).collectArg3(f3).collectArg4(f4)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3.collect4
+
+  def prepare(action: (T1, T2, T3, T4) => (T1, T2, T3, T4)): SelfType =
+    copy(execute = (t1: T1, t2: T2, t3: T3, t4: T4) => execute.tupled(action(t1, t2, t3, t4)))
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction5[F[_]: MonadThrow, T1, T2, T3, T4, T5, R](
+    execute: (T1, T2, T3, T4, T5) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    argInstances4: ScalaCheckArgInstances[T4],
+    argInstances5: ScalaCheckArgInstances[T5],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction5[F, T1, T2, T3, T4, T5, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given Arbitrary[T4] = argInstances4.arbitrary
+  private given Arbitrary[T5] = argInstances5.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+  private given (T4 => Pretty) = argInstances4.pretty
+  private given (T5 => Pretty) = argInstances5.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => {
+    lazy val executed = execute(t1, t2, t3, t4, t5)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) =>
+            makePropF(
+              (t3: T3) =>
+                makePropF(
+                  (t4: T4) => makePropF((t5: T5) => propFunction(t1, t2, t3, t4, t5), argInstances5.shrink, parameters),
+                  argInstances4.shrink,
+                  parameters
+                ),
+              argInstances3.shrink,
+              parameters
+            ),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None),
+    argInstances4 = argInstances4.copy(shrink = None),
+    argInstances5 = argInstances5.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitrary4(a4: Arbitrary[T4]): SelfType = copy(argInstances4 = argInstances4.copy(arbitrary = a4))
+  def setArbitrary5(a5: Arbitrary[T5]): SelfType = copy(argInstances5 = argInstances5.copy(arbitrary = a5))
+  def setArbitraries(
+      a1: Arbitrary[T1],
+      a2: Arbitrary[T2],
+      a3: Arbitrary[T3],
+      a4: Arbitrary[T4],
+      a5: Arbitrary[T5]
+  ): SelfType =
+    setArbitrary1(a1).setArbitrary2(a2).setArbitrary3(a3).setArbitrary4(a4).setArbitrary5(a5)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGen4(g4: Gen[T4]): SelfType = setArbitrary4(Arbitrary(g4))
+  def setGen5(g5: Gen[T5]): SelfType = setArbitrary5(Arbitrary(g5))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5]): SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3).setGen4(g4).setGen5(g5)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrink4(s4: Shrink[T4]): SelfType = copy(argInstances4 = argInstances4.copy(shrink = Some(s4)))
+  def setShrink5(s5: Shrink[T5]): SelfType = copy(argInstances5 = argInstances5.copy(shrink = Some(s5)))
+  def setShrinks(s1: Shrink[T1], s2: Shrink[T2], s3: Shrink[T3], s4: Shrink[T4], s5: Shrink[T5]): SelfType =
+    setShrink1(s1).setShrink2(s2).setShrink3(s3).setShrink4(s4).setShrink5(s5)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def setPretty4(p4: T4 => Pretty): SelfType = copy(argInstances4 = argInstances4.copy(pretty = p4))
+  def setPretty5(p5: T5 => Pretty): SelfType = copy(argInstances5 = argInstances5.copy(pretty = p5))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+  def pretty4(p4: T4 => String): SelfType = setPretty4((t4: T4) => Pretty(_ => p4(t4)))
+  def pretty5(p5: T5 => String): SelfType = setPretty5((t5: T5) => Pretty(_ => p5(t5)))
+
+  def setPretties(p1: T1 => Pretty, p2: T2 => Pretty, p3: T3 => Pretty, p4: T4 => Pretty, p5: T5 => Pretty): SelfType =
+    setPretty1(p1).setPretty2(p2).setPretty3(p3).setPretty4(p4).setPretty5(p5)
+  def pretties(p1: T1 => String, p2: T2 => String, p3: T3 => String, p4: T4 => String, p5: T5 => String): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3).pretty4(p4).pretty5(p5)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collectArg4(f: T4 => Any): SelfType =
+    copy(argInstances4 = argInstances4.copy(collectors = argInstances4.collectors :+ f))
+  def collectArg5(f: T5 => Any): SelfType =
+    copy(argInstances5 = argInstances5.copy(collectors = argInstances5.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collect4: SelfType = collectArg4(_.toString)
+  def collect5: SelfType = collectArg5(_.toString)
+  def collectAllArgs(f1: T1 => Any, f2: T2 => Any, f3: T3 => Any, f4: T4 => Any, f5: T5 => Any): SelfType =
+    collectArg1(f1).collectArg2(f2).collectArg3(f3).collectArg4(f4).collectArg5(f5)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3.collect4.collect5
+
+  def prepare(action: (T1, T2, T3, T4, T5) => (T1, T2, T3, T4, T5)): SelfType =
+    copy(execute = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5) => execute.tupled(action(t1, t2, t3, t4, t5)))
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction6[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, R](
+    execute: (T1, T2, T3, T4, T5, T6) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    argInstances4: ScalaCheckArgInstances[T4],
+    argInstances5: ScalaCheckArgInstances[T5],
+    argInstances6: ScalaCheckArgInstances[T6],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction6[F, T1, T2, T3, T4, T5, T6, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given Arbitrary[T4] = argInstances4.arbitrary
+  private given Arbitrary[T5] = argInstances5.arbitrary
+  private given Arbitrary[T6] = argInstances6.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+  private given (T4 => Pretty) = argInstances4.pretty
+  private given (T5 => Pretty) = argInstances5.pretty
+  private given (T6 => Pretty) = argInstances6.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => {
+    lazy val executed = execute(t1, t2, t3, t4, t5, t6)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) =>
+            makePropF(
+              (t3: T3) =>
+                makePropF(
+                  (t4: T4) =>
+                    makePropF(
+                      (t5: T5) =>
+                        makePropF((t6: T6) => propFunction(t1, t2, t3, t4, t5, t6), argInstances6.shrink, parameters),
+                      argInstances5.shrink,
+                      parameters
+                    ),
+                  argInstances4.shrink,
+                  parameters
+                ),
+              argInstances3.shrink,
+              parameters
+            ),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None),
+    argInstances4 = argInstances4.copy(shrink = None),
+    argInstances5 = argInstances5.copy(shrink = None),
+    argInstances6 = argInstances6.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitrary4(a4: Arbitrary[T4]): SelfType = copy(argInstances4 = argInstances4.copy(arbitrary = a4))
+  def setArbitrary5(a5: Arbitrary[T5]): SelfType = copy(argInstances5 = argInstances5.copy(arbitrary = a5))
+  def setArbitrary6(a6: Arbitrary[T6]): SelfType = copy(argInstances6 = argInstances6.copy(arbitrary = a6))
+  def setArbitraries(
+      a1: Arbitrary[T1],
+      a2: Arbitrary[T2],
+      a3: Arbitrary[T3],
+      a4: Arbitrary[T4],
+      a5: Arbitrary[T5],
+      a6: Arbitrary[T6]
+  ): SelfType =
+    setArbitrary1(a1).setArbitrary2(a2).setArbitrary3(a3).setArbitrary4(a4).setArbitrary5(a5).setArbitrary6(a6)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGen4(g4: Gen[T4]): SelfType = setArbitrary4(Arbitrary(g4))
+  def setGen5(g5: Gen[T5]): SelfType = setArbitrary5(Arbitrary(g5))
+  def setGen6(g6: Gen[T6]): SelfType = setArbitrary6(Arbitrary(g6))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6]): SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3).setGen4(g4).setGen5(g5).setGen6(g6)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrink4(s4: Shrink[T4]): SelfType = copy(argInstances4 = argInstances4.copy(shrink = Some(s4)))
+  def setShrink5(s5: Shrink[T5]): SelfType = copy(argInstances5 = argInstances5.copy(shrink = Some(s5)))
+  def setShrink6(s6: Shrink[T6]): SelfType = copy(argInstances6 = argInstances6.copy(shrink = Some(s6)))
+  def setShrinks(
+      s1: Shrink[T1],
+      s2: Shrink[T2],
+      s3: Shrink[T3],
+      s4: Shrink[T4],
+      s5: Shrink[T5],
+      s6: Shrink[T6]
+  ): SelfType =
+    setShrink1(s1).setShrink2(s2).setShrink3(s3).setShrink4(s4).setShrink5(s5).setShrink6(s6)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def setPretty4(p4: T4 => Pretty): SelfType = copy(argInstances4 = argInstances4.copy(pretty = p4))
+  def setPretty5(p5: T5 => Pretty): SelfType = copy(argInstances5 = argInstances5.copy(pretty = p5))
+  def setPretty6(p6: T6 => Pretty): SelfType = copy(argInstances6 = argInstances6.copy(pretty = p6))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+  def pretty4(p4: T4 => String): SelfType = setPretty4((t4: T4) => Pretty(_ => p4(t4)))
+  def pretty5(p5: T5 => String): SelfType = setPretty5((t5: T5) => Pretty(_ => p5(t5)))
+  def pretty6(p6: T6 => String): SelfType = setPretty6((t6: T6) => Pretty(_ => p6(t6)))
+
+  def setPretties(
+      p1: T1 => Pretty,
+      p2: T2 => Pretty,
+      p3: T3 => Pretty,
+      p4: T4 => Pretty,
+      p5: T5 => Pretty,
+      p6: T6 => Pretty
+  ): SelfType =
+    setPretty1(p1).setPretty2(p2).setPretty3(p3).setPretty4(p4).setPretty5(p5).setPretty6(p6)
+  def pretties(
+      p1: T1 => String,
+      p2: T2 => String,
+      p3: T3 => String,
+      p4: T4 => String,
+      p5: T5 => String,
+      p6: T6 => String
+  ): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3).pretty4(p4).pretty5(p5).pretty6(p6)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collectArg4(f: T4 => Any): SelfType =
+    copy(argInstances4 = argInstances4.copy(collectors = argInstances4.collectors :+ f))
+  def collectArg5(f: T5 => Any): SelfType =
+    copy(argInstances5 = argInstances5.copy(collectors = argInstances5.collectors :+ f))
+  def collectArg6(f: T6 => Any): SelfType =
+    copy(argInstances6 = argInstances6.copy(collectors = argInstances6.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collect4: SelfType = collectArg4(_.toString)
+  def collect5: SelfType = collectArg5(_.toString)
+  def collect6: SelfType = collectArg6(_.toString)
+  def collectAllArgs(
+      f1: T1 => Any,
+      f2: T2 => Any,
+      f3: T3 => Any,
+      f4: T4 => Any,
+      f5: T5 => Any,
+      f6: T6 => Any
+  ): SelfType =
+    collectArg1(f1).collectArg2(f2).collectArg3(f3).collectArg4(f4).collectArg5(f5).collectArg6(f6)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3.collect4.collect5.collect6
+
+  def prepare(action: (T1, T2, T3, T4, T5, T6) => (T1, T2, T3, T4, T5, T6)): SelfType =
+    copy(execute = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6) => execute.tupled(action(t1, t2, t3, t4, t5, t6)))
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction7[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, T7, R](
+    execute: (T1, T2, T3, T4, T5, T6, T7) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    argInstances4: ScalaCheckArgInstances[T4],
+    argInstances5: ScalaCheckArgInstances[T5],
+    argInstances6: ScalaCheckArgInstances[T6],
+    argInstances7: ScalaCheckArgInstances[T7],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction7[F, T1, T2, T3, T4, T5, T6, T7, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given Arbitrary[T4] = argInstances4.arbitrary
+  private given Arbitrary[T5] = argInstances5.arbitrary
+  private given Arbitrary[T6] = argInstances6.arbitrary
+  private given Arbitrary[T7] = argInstances7.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+  private given (T4 => Pretty) = argInstances4.pretty
+  private given (T5 => Pretty) = argInstances5.pretty
+  private given (T6 => Pretty) = argInstances6.pretty
+  private given (T7 => Pretty) = argInstances7.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7) => {
+    lazy val executed = execute(t1, t2, t3, t4, t5, t6, t7)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) =>
+            makePropF(
+              (t3: T3) =>
+                makePropF(
+                  (t4: T4) =>
+                    makePropF(
+                      (t5: T5) =>
+                        makePropF(
+                          (t6: T6) =>
+                            makePropF(
+                              (t7: T7) => propFunction(t1, t2, t3, t4, t5, t6, t7),
+                              argInstances7.shrink,
+                              parameters
+                            ),
+                          argInstances6.shrink,
+                          parameters
+                        ),
+                      argInstances5.shrink,
+                      parameters
+                    ),
+                  argInstances4.shrink,
+                  parameters
+                ),
+              argInstances3.shrink,
+              parameters
+            ),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None),
+    argInstances4 = argInstances4.copy(shrink = None),
+    argInstances5 = argInstances5.copy(shrink = None),
+    argInstances6 = argInstances6.copy(shrink = None),
+    argInstances7 = argInstances7.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitrary4(a4: Arbitrary[T4]): SelfType = copy(argInstances4 = argInstances4.copy(arbitrary = a4))
+  def setArbitrary5(a5: Arbitrary[T5]): SelfType = copy(argInstances5 = argInstances5.copy(arbitrary = a5))
+  def setArbitrary6(a6: Arbitrary[T6]): SelfType = copy(argInstances6 = argInstances6.copy(arbitrary = a6))
+  def setArbitrary7(a7: Arbitrary[T7]): SelfType = copy(argInstances7 = argInstances7.copy(arbitrary = a7))
+  def setArbitraries(
+      a1: Arbitrary[T1],
+      a2: Arbitrary[T2],
+      a3: Arbitrary[T3],
+      a4: Arbitrary[T4],
+      a5: Arbitrary[T5],
+      a6: Arbitrary[T6],
+      a7: Arbitrary[T7]
+  ): SelfType =
+    setArbitrary1(a1)
+      .setArbitrary2(a2)
+      .setArbitrary3(a3)
+      .setArbitrary4(a4)
+      .setArbitrary5(a5)
+      .setArbitrary6(a6)
+      .setArbitrary7(a7)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGen4(g4: Gen[T4]): SelfType = setArbitrary4(Arbitrary(g4))
+  def setGen5(g5: Gen[T5]): SelfType = setArbitrary5(Arbitrary(g5))
+  def setGen6(g6: Gen[T6]): SelfType = setArbitrary6(Arbitrary(g6))
+  def setGen7(g7: Gen[T7]): SelfType = setArbitrary7(Arbitrary(g7))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7]): SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3).setGen4(g4).setGen5(g5).setGen6(g6).setGen7(g7)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrink4(s4: Shrink[T4]): SelfType = copy(argInstances4 = argInstances4.copy(shrink = Some(s4)))
+  def setShrink5(s5: Shrink[T5]): SelfType = copy(argInstances5 = argInstances5.copy(shrink = Some(s5)))
+  def setShrink6(s6: Shrink[T6]): SelfType = copy(argInstances6 = argInstances6.copy(shrink = Some(s6)))
+  def setShrink7(s7: Shrink[T7]): SelfType = copy(argInstances7 = argInstances7.copy(shrink = Some(s7)))
+  def setShrinks(
+      s1: Shrink[T1],
+      s2: Shrink[T2],
+      s3: Shrink[T3],
+      s4: Shrink[T4],
+      s5: Shrink[T5],
+      s6: Shrink[T6],
+      s7: Shrink[T7]
+  ): SelfType =
+    setShrink1(s1).setShrink2(s2).setShrink3(s3).setShrink4(s4).setShrink5(s5).setShrink6(s6).setShrink7(s7)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def setPretty4(p4: T4 => Pretty): SelfType = copy(argInstances4 = argInstances4.copy(pretty = p4))
+  def setPretty5(p5: T5 => Pretty): SelfType = copy(argInstances5 = argInstances5.copy(pretty = p5))
+  def setPretty6(p6: T6 => Pretty): SelfType = copy(argInstances6 = argInstances6.copy(pretty = p6))
+  def setPretty7(p7: T7 => Pretty): SelfType = copy(argInstances7 = argInstances7.copy(pretty = p7))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+  def pretty4(p4: T4 => String): SelfType = setPretty4((t4: T4) => Pretty(_ => p4(t4)))
+  def pretty5(p5: T5 => String): SelfType = setPretty5((t5: T5) => Pretty(_ => p5(t5)))
+  def pretty6(p6: T6 => String): SelfType = setPretty6((t6: T6) => Pretty(_ => p6(t6)))
+  def pretty7(p7: T7 => String): SelfType = setPretty7((t7: T7) => Pretty(_ => p7(t7)))
+
+  def setPretties(
+      p1: T1 => Pretty,
+      p2: T2 => Pretty,
+      p3: T3 => Pretty,
+      p4: T4 => Pretty,
+      p5: T5 => Pretty,
+      p6: T6 => Pretty,
+      p7: T7 => Pretty
+  ): SelfType =
+    setPretty1(p1).setPretty2(p2).setPretty3(p3).setPretty4(p4).setPretty5(p5).setPretty6(p6).setPretty7(p7)
+  def pretties(
+      p1: T1 => String,
+      p2: T2 => String,
+      p3: T3 => String,
+      p4: T4 => String,
+      p5: T5 => String,
+      p6: T6 => String,
+      p7: T7 => String
+  ): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3).pretty4(p4).pretty5(p5).pretty6(p6).pretty7(p7)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collectArg4(f: T4 => Any): SelfType =
+    copy(argInstances4 = argInstances4.copy(collectors = argInstances4.collectors :+ f))
+  def collectArg5(f: T5 => Any): SelfType =
+    copy(argInstances5 = argInstances5.copy(collectors = argInstances5.collectors :+ f))
+  def collectArg6(f: T6 => Any): SelfType =
+    copy(argInstances6 = argInstances6.copy(collectors = argInstances6.collectors :+ f))
+  def collectArg7(f: T7 => Any): SelfType =
+    copy(argInstances7 = argInstances7.copy(collectors = argInstances7.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collect4: SelfType = collectArg4(_.toString)
+  def collect5: SelfType = collectArg5(_.toString)
+  def collect6: SelfType = collectArg6(_.toString)
+  def collect7: SelfType = collectArg7(_.toString)
+  def collectAllArgs(
+      f1: T1 => Any,
+      f2: T2 => Any,
+      f3: T3 => Any,
+      f4: T4 => Any,
+      f5: T5 => Any,
+      f6: T6 => Any,
+      f7: T7 => Any
+  ): SelfType =
+    collectArg1(f1).collectArg2(f2).collectArg3(f3).collectArg4(f4).collectArg5(f5).collectArg6(f6).collectArg7(f7)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3.collect4.collect5.collect6.collect7
+
+  def prepare(action: (T1, T2, T3, T4, T5, T6, T7) => (T1, T2, T3, T4, T5, T6, T7)): SelfType =
+    copy(execute =
+      (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7) => execute.tupled(action(t1, t2, t3, t4, t5, t6, t7))
+    )
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}
+
+case class ScalaCheckEffectFunction8[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, T7, T8, R](
+    execute: (T1, T2, T3, T4, T5, T6, T7, T8) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    argInstances3: ScalaCheckArgInstances[T3],
+    argInstances4: ScalaCheckArgInstances[T4],
+    argInstances5: ScalaCheckArgInstances[T5],
+    argInstances6: ScalaCheckArgInstances[T6],
+    argInstances7: ScalaCheckArgInstances[T7],
+    argInstances8: ScalaCheckArgInstances[T8],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction8[F, T1, T2, T3, T4, T5, T6, T7, T8, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given Arbitrary[T3] = argInstances3.arbitrary
+  private given Arbitrary[T4] = argInstances4.arbitrary
+  private given Arbitrary[T5] = argInstances5.arbitrary
+  private given Arbitrary[T6] = argInstances6.arbitrary
+  private given Arbitrary[T7] = argInstances7.arbitrary
+  private given Arbitrary[T8] = argInstances8.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+  private given (T3 => Pretty) = argInstances3.pretty
+  private given (T4 => Pretty) = argInstances4.pretty
+  private given (T5 => Pretty) = argInstances5.pretty
+  private given (T6 => Pretty) = argInstances6.pretty
+  private given (T7 => Pretty) = argInstances7.pretty
+  private given (T8 => Pretty) = argInstances8.pretty
+
+  lazy val propFunction = (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8) => {
+    lazy val executed = execute(t1, t2, t3, t4, t5, t6, t7, t8)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) =>
+        makePropF(
+          (t2: T2) =>
+            makePropF(
+              (t3: T3) =>
+                makePropF(
+                  (t4: T4) =>
+                    makePropF(
+                      (t5: T5) =>
+                        makePropF(
+                          (t6: T6) =>
+                            makePropF(
+                              (t7: T7) =>
+                                makePropF(
+                                  (t8: T8) => propFunction(t1, t2, t3, t4, t5, t6, t7, t8),
+                                  argInstances8.shrink,
+                                  parameters
+                                ),
+                              argInstances7.shrink,
+                              parameters
+                            ),
+                          argInstances6.shrink,
+                          parameters
+                        ),
+                      argInstances5.shrink,
+                      parameters
+                    ),
+                  argInstances4.shrink,
+                  parameters
+                ),
+              argInstances3.shrink,
+              parameters
+            ),
+          argInstances2.shrink,
+          parameters
+        ),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType = copy(
+    argInstances1 = argInstances1.copy(shrink = None),
+    argInstances2 = argInstances2.copy(shrink = None),
+    argInstances3 = argInstances3.copy(shrink = None),
+    argInstances4 = argInstances4.copy(shrink = None),
+    argInstances5 = argInstances5.copy(shrink = None),
+    argInstances6 = argInstances6.copy(shrink = None),
+    argInstances7 = argInstances7.copy(shrink = None),
+    argInstances8 = argInstances8.copy(shrink = None)
+  )
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitrary3(a3: Arbitrary[T3]): SelfType = copy(argInstances3 = argInstances3.copy(arbitrary = a3))
+  def setArbitrary4(a4: Arbitrary[T4]): SelfType = copy(argInstances4 = argInstances4.copy(arbitrary = a4))
+  def setArbitrary5(a5: Arbitrary[T5]): SelfType = copy(argInstances5 = argInstances5.copy(arbitrary = a5))
+  def setArbitrary6(a6: Arbitrary[T6]): SelfType = copy(argInstances6 = argInstances6.copy(arbitrary = a6))
+  def setArbitrary7(a7: Arbitrary[T7]): SelfType = copy(argInstances7 = argInstances7.copy(arbitrary = a7))
+  def setArbitrary8(a8: Arbitrary[T8]): SelfType = copy(argInstances8 = argInstances8.copy(arbitrary = a8))
+  def setArbitraries(
+      a1: Arbitrary[T1],
+      a2: Arbitrary[T2],
+      a3: Arbitrary[T3],
+      a4: Arbitrary[T4],
+      a5: Arbitrary[T5],
+      a6: Arbitrary[T6],
+      a7: Arbitrary[T7],
+      a8: Arbitrary[T8]
+  ): SelfType =
+    setArbitrary1(a1)
+      .setArbitrary2(a2)
+      .setArbitrary3(a3)
+      .setArbitrary4(a4)
+      .setArbitrary5(a5)
+      .setArbitrary6(a6)
+      .setArbitrary7(a7)
+      .setArbitrary8(a8)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGen3(g3: Gen[T3]): SelfType = setArbitrary3(Arbitrary(g3))
+  def setGen4(g4: Gen[T4]): SelfType = setArbitrary4(Arbitrary(g4))
+  def setGen5(g5: Gen[T5]): SelfType = setArbitrary5(Arbitrary(g5))
+  def setGen6(g6: Gen[T6]): SelfType = setArbitrary6(Arbitrary(g6))
+  def setGen7(g7: Gen[T7]): SelfType = setArbitrary7(Arbitrary(g7))
+  def setGen8(g8: Gen[T8]): SelfType = setArbitrary8(Arbitrary(g8))
+  def setGens(g1: Gen[T1], g2: Gen[T2], g3: Gen[T3], g4: Gen[T4], g5: Gen[T5], g6: Gen[T6], g7: Gen[T7], g8: Gen[T8])
+      : SelfType =
+    setGen1(g1).setGen2(g2).setGen3(g3).setGen4(g4).setGen5(g5).setGen6(g6).setGen7(g7).setGen8(g8)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrink3(s3: Shrink[T3]): SelfType = copy(argInstances3 = argInstances3.copy(shrink = Some(s3)))
+  def setShrink4(s4: Shrink[T4]): SelfType = copy(argInstances4 = argInstances4.copy(shrink = Some(s4)))
+  def setShrink5(s5: Shrink[T5]): SelfType = copy(argInstances5 = argInstances5.copy(shrink = Some(s5)))
+  def setShrink6(s6: Shrink[T6]): SelfType = copy(argInstances6 = argInstances6.copy(shrink = Some(s6)))
+  def setShrink7(s7: Shrink[T7]): SelfType = copy(argInstances7 = argInstances7.copy(shrink = Some(s7)))
+  def setShrink8(s8: Shrink[T8]): SelfType = copy(argInstances8 = argInstances8.copy(shrink = Some(s8)))
+  def setShrinks(
+      s1: Shrink[T1],
+      s2: Shrink[T2],
+      s3: Shrink[T3],
+      s4: Shrink[T4],
+      s5: Shrink[T5],
+      s6: Shrink[T6],
+      s7: Shrink[T7],
+      s8: Shrink[T8]
+  ): SelfType =
+    setShrink1(s1)
+      .setShrink2(s2)
+      .setShrink3(s3)
+      .setShrink4(s4)
+      .setShrink5(s5)
+      .setShrink6(s6)
+      .setShrink7(s7)
+      .setShrink8(s8)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def setPretty3(p3: T3 => Pretty): SelfType = copy(argInstances3 = argInstances3.copy(pretty = p3))
+  def setPretty4(p4: T4 => Pretty): SelfType = copy(argInstances4 = argInstances4.copy(pretty = p4))
+  def setPretty5(p5: T5 => Pretty): SelfType = copy(argInstances5 = argInstances5.copy(pretty = p5))
+  def setPretty6(p6: T6 => Pretty): SelfType = copy(argInstances6 = argInstances6.copy(pretty = p6))
+  def setPretty7(p7: T7 => Pretty): SelfType = copy(argInstances7 = argInstances7.copy(pretty = p7))
+  def setPretty8(p8: T8 => Pretty): SelfType = copy(argInstances8 = argInstances8.copy(pretty = p8))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+  def pretty3(p3: T3 => String): SelfType = setPretty3((t3: T3) => Pretty(_ => p3(t3)))
+  def pretty4(p4: T4 => String): SelfType = setPretty4((t4: T4) => Pretty(_ => p4(t4)))
+  def pretty5(p5: T5 => String): SelfType = setPretty5((t5: T5) => Pretty(_ => p5(t5)))
+  def pretty6(p6: T6 => String): SelfType = setPretty6((t6: T6) => Pretty(_ => p6(t6)))
+  def pretty7(p7: T7 => String): SelfType = setPretty7((t7: T7) => Pretty(_ => p7(t7)))
+  def pretty8(p8: T8 => String): SelfType = setPretty8((t8: T8) => Pretty(_ => p8(t8)))
+
+  def setPretties(
+      p1: T1 => Pretty,
+      p2: T2 => Pretty,
+      p3: T3 => Pretty,
+      p4: T4 => Pretty,
+      p5: T5 => Pretty,
+      p6: T6 => Pretty,
+      p7: T7 => Pretty,
+      p8: T8 => Pretty
+  ): SelfType =
+    setPretty1(p1)
+      .setPretty2(p2)
+      .setPretty3(p3)
+      .setPretty4(p4)
+      .setPretty5(p5)
+      .setPretty6(p6)
+      .setPretty7(p7)
+      .setPretty8(p8)
+  def pretties(
+      p1: T1 => String,
+      p2: T2 => String,
+      p3: T3 => String,
+      p4: T4 => String,
+      p5: T5 => String,
+      p6: T6 => String,
+      p7: T7 => String,
+      p8: T8 => String
+  ): SelfType =
+    pretty1(p1).pretty2(p2).pretty3(p3).pretty4(p4).pretty5(p5).pretty6(p6).pretty7(p7).pretty8(p8)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collectArg3(f: T3 => Any): SelfType =
+    copy(argInstances3 = argInstances3.copy(collectors = argInstances3.collectors :+ f))
+  def collectArg4(f: T4 => Any): SelfType =
+    copy(argInstances4 = argInstances4.copy(collectors = argInstances4.collectors :+ f))
+  def collectArg5(f: T5 => Any): SelfType =
+    copy(argInstances5 = argInstances5.copy(collectors = argInstances5.collectors :+ f))
+  def collectArg6(f: T6 => Any): SelfType =
+    copy(argInstances6 = argInstances6.copy(collectors = argInstances6.collectors :+ f))
+  def collectArg7(f: T7 => Any): SelfType =
+    copy(argInstances7 = argInstances7.copy(collectors = argInstances7.collectors :+ f))
+  def collectArg8(f: T8 => Any): SelfType =
+    copy(argInstances8 = argInstances8.copy(collectors = argInstances8.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collect3: SelfType = collectArg3(_.toString)
+  def collect4: SelfType = collectArg4(_.toString)
+  def collect5: SelfType = collectArg5(_.toString)
+  def collect6: SelfType = collectArg6(_.toString)
+  def collect7: SelfType = collectArg7(_.toString)
+  def collect8: SelfType = collectArg8(_.toString)
+  def collectAllArgs(
+      f1: T1 => Any,
+      f2: T2 => Any,
+      f3: T3 => Any,
+      f4: T4 => Any,
+      f5: T5 => Any,
+      f6: T6 => Any,
+      f7: T7 => Any,
+      f8: T8 => Any
+  ): SelfType =
+    collectArg1(f1)
+      .collectArg2(f2)
+      .collectArg3(f3)
+      .collectArg4(f4)
+      .collectArg5(f5)
+      .collectArg6(f6)
+      .collectArg7(f7)
+      .collectArg8(f8)
+
+  def collectAll: SelfType =
+    collect1.collect2.collect3.collect4.collect5.collect6.collect7.collect8
+
+  def prepare(action: (T1, T2, T3, T4, T5, T6, T7, T8) => (T1, T2, T3, T4, T5, T6, T7, T8)): SelfType =
+    copy(execute =
+      (t1: T1, t2: T2, t3: T3, t4: T4, t5: T5, t6: T6, t7: T7, t8: T8) =>
+        execute.tupled(action(t1, t2, t3, t4, t5, t6, t7, t8))
+    )
 
   def setContext(context: Context): SelfType =
     copy(context = Some(context))

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
@@ -2,6 +2,7 @@ package org.specs2
 package scalacheck
 package effect
 
+import cats.MonadThrow
 import org.scalacheck.*
 import org.scalacheck.effect.PropF
 import org.scalacheck.rng.Seed
@@ -11,8 +12,8 @@ import org.scalacheck.util.Pretty
 import execute.*
 import specification.*
 import core.{AsExecution, Execution}
-import AsResultProp.{given, *}
-import ScalaCheckProperty.{given, *}
+import AsResultPropF.{given, *}
+import ScalaCheckEffectProperty.{given, *}
 
 /** A ScalaCheckProperty encapsulates a ScalaCheck Prop and its parameters
   */
@@ -86,3 +87,211 @@ trait ScalaCheckEffectProperty[F[_]]:
   def prettyFreqMap(f: FreqMap[Set[Any]] => String): SelfType =
     setPrettyFreqMap((fq: FreqMap[Set[Any]]) => Pretty(_ => f(fq)))
 
+object ScalaCheckEffectProperty:
+
+  given ScalaCheckEffectPropertyAsExecution[F[_]: MonadThrow, S <: ScalaCheckEffectProperty[F]](using
+      AsExecution[F[Result]]
+  ): AsExecution[S] with
+    def execute(s: =>S): Execution =
+      Execution.withEnvFlatten { env =>
+        AsResultPropF.check(s.propF, s.parameters.overrideWith(env.commandLine), s.prettyFreqMap)
+      }
+
+  def makePropF[F[_]: MonadThrow, T](f: T => PropF[F], shrink: Option[Shrink[T]], parameters: Parameters)(implicit
+      a: Arbitrary[T],
+      p: T => Pretty
+  ): PropF[F] =
+    shrink match
+      case Some(s) => PropF.forAllShrinkF(a.arbitrary, s.shrink)(f)
+      case _       => PropF.forAllNoShrinkF(f)
+
+/** A ScalaCheckFunction adds the possibility to select various typeclass instances for a given property:
+  *
+  *   - Arbitrary to generate values
+  *   - Shrink to shrink counter-examples
+  *   - Show to display arguments in case of a counter-example
+  *   - Collector to collect values and provide a summary as string (to show frequencies for example)
+  */
+trait ScalaCheckEffectFunction[F[_]] extends ScalaCheckEffectProperty[F]:
+  def noShrink: SelfType
+
+  def context: Option[Context]
+
+  def setContext(context: Context): SelfType
+
+  def before(action: =>Any): SelfType =
+    setContext(Before.create(action))
+
+  def after(action: =>Any): SelfType =
+    setContext(After.create(action))
+
+  def beforeAfter(beforeAction: =>Any, afterAction: =>Any): SelfType =
+    setContext(BeforeAfter.create(beforeAction, afterAction))
+
+  def around(action: Result => Result): SelfType =
+    setContext(Around.create(action))
+
+  protected def executeInContext[R: AsResult](result: =>R) = {
+    lazy val executed = result
+    context.foreach(_(executed))
+    executed.asInstanceOf[Matchable] match {
+      case p: Prop => p
+      case other   => AsResultProp.asResultToProp.apply(other.asInstanceOf[R])
+    }
+  }
+
+case class ScalaCheckEffectFunction1[F[_]: MonadThrow, T, R](
+    execute: T => F[R],
+    arbitrary: Arbitrary[T],
+    shrink: Option[Shrink[T]],
+    collectors: List[T => Any],
+    pretty: T => Pretty,
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F]:
+
+  type SelfType = ScalaCheckEffectFunction1[F, T, R]
+
+  private given asResult1: AsResult[R] = asResult
+  private given arbitrary1: Arbitrary[T] = arbitrary
+  private given pretty1: (T => Pretty) = pretty
+
+  lazy val propFFunction = (t: T) => {
+    lazy val executed = execute(t)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(propFFunction, shrink, parameters)
+
+  def noShrink: SelfType = copy(shrink = None, pretty = pretty1)
+
+  def setArbitrary(arbitrary: Arbitrary[T]): SelfType =
+    copy(arbitrary = arbitrary, pretty = pretty1)
+
+  def setGen(gen: Gen[T]): SelfType =
+    setArbitrary(Arbitrary(gen))
+
+  def setShrink(shrink: Shrink[T]): SelfType =
+    copy(shrink = Some(shrink), pretty = pretty1)
+
+  def setPretty(pretty: T => Pretty): SelfType =
+    copy(pretty = pretty1)
+
+  def pretty(pretty: T => String): SelfType =
+    setPretty((t: T) => Pretty(_ => pretty(t)))
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f, pretty = pretty1)
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps, pretty = pretty1)
+
+  def collect: SelfType =
+    collectArg(_.toString)
+
+  def collectArg(f: T => Any): SelfType =
+    copy(collectors = collectors :+ f, pretty = pretty1)
+
+  def prepare(action: T => T): SelfType =
+    copy(execute = (t: T) => execute(action(t)), pretty = pretty)
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context), pretty = pretty)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)), pretty = pretty1)
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)), pretty = pretty1)
+
+case class ScalaCheckEffectFunction2[F[_]: MonadThrow, T1, T2, R](
+    execute: (T1, T2) => F[R],
+    argInstances1: ScalaCheckArgInstances[T1],
+    argInstances2: ScalaCheckArgInstances[T2],
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+    asResult: AsResult[R],
+    context: Option[Context],
+    parameters: Parameters
+) extends ScalaCheckEffectFunction[F] {
+
+  type SelfType = ScalaCheckEffectFunction2[F, T1, T2, R]
+
+  private given AsResult[R] = asResult
+  private given Arbitrary[T1] = argInstances1.arbitrary
+  private given Arbitrary[T2] = argInstances2.arbitrary
+  private given (T1 => Pretty) = argInstances1.pretty
+  private given (T2 => Pretty) = argInstances2.pretty
+
+  lazy val propFFunction = (t1: T1, t2: T2) => {
+    lazy val executed = execute(t1, t2)
+    executed: PropF[F]
+  }
+
+  lazy val propF: PropF[F] =
+    makePropF(
+      (t1: T1) => makePropF((t2: T2) => propFFunction(t1, t2), argInstances2.shrink, parameters),
+      argInstances1.shrink,
+      parameters
+    )
+
+  def noShrink: SelfType =
+    copy(argInstances1 = argInstances1.copy(shrink = None), argInstances2 = argInstances2.copy(shrink = None))
+
+  def setArbitrary1(a1: Arbitrary[T1]): SelfType = copy(argInstances1 = argInstances1.copy(arbitrary = a1))
+  def setArbitrary2(a2: Arbitrary[T2]): SelfType = copy(argInstances2 = argInstances2.copy(arbitrary = a2))
+  def setArbitraries(a1: Arbitrary[T1], a2: Arbitrary[T2]): SelfType =
+    setArbitrary1(a1).setArbitrary2(a2)
+
+  def setGen1(g1: Gen[T1]): SelfType = setArbitrary1(Arbitrary(g1))
+  def setGen2(g2: Gen[T2]): SelfType = setArbitrary2(Arbitrary(g2))
+  def setGens(g1: Gen[T1], g2: Gen[T2]): SelfType =
+    setGen1(g1).setGen2(g2)
+
+  def setShrink1(s1: Shrink[T1]): SelfType = copy(argInstances1 = argInstances1.copy(shrink = Some(s1)))
+  def setShrink2(s2: Shrink[T2]): SelfType = copy(argInstances2 = argInstances2.copy(shrink = Some(s2)))
+  def setShrinks(s1: Shrink[T1], s2: Shrink[T2]): SelfType =
+    setShrink1(s1).setShrink2(s2)
+
+  def setPretty1(p1: T1 => Pretty): SelfType = copy(argInstances1 = argInstances1.copy(pretty = p1))
+  def setPretty2(p2: T2 => Pretty): SelfType = copy(argInstances2 = argInstances2.copy(pretty = p2))
+  def pretty1(p1: T1 => String): SelfType = setPretty1((t1: T1) => Pretty(_ => p1(t1)))
+  def pretty2(p2: T2 => String): SelfType = setPretty2((t2: T2) => Pretty(_ => p2(t2)))
+
+  def setPretties(p1: T1 => Pretty, p2: T2 => Pretty): SelfType =
+    setPretty1(p1).setPretty2(p2)
+  def pretties(p1: T1 => String, p2: T2 => String): SelfType =
+    pretty1(p1).pretty2(p2)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)
+
+  def collectArg1(f: T1 => Any): SelfType =
+    copy(argInstances1 = argInstances1.copy(collectors = argInstances1.collectors :+ f))
+  def collectArg2(f: T2 => Any): SelfType =
+    copy(argInstances2 = argInstances2.copy(collectors = argInstances2.collectors :+ f))
+  def collect1: SelfType = collectArg1(_.toString)
+  def collect2: SelfType = collectArg2(_.toString)
+  def collectAllArgs(f1: T1 => Any, f2: T2 => Any): SelfType =
+    collectArg1(f1).collectArg2(f2)
+
+  def collectAll: SelfType =
+    collect1.collect2
+
+  def prepare(action: (T1, T2) => (T1, T2)): SelfType =
+    copy(execute = (t1: T1, t2: T2) => execute.tupled(action(t1, t2)))
+
+  def setContext(context: Context): SelfType =
+    copy(context = Some(context))
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+}

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
@@ -1,0 +1,88 @@
+package org.specs2
+package scalacheck
+package effect
+
+import org.scalacheck.*
+import org.scalacheck.effect.PropF
+import org.scalacheck.rng.Seed
+import org.scalacheck.util.FreqMap
+import org.scalacheck.util.Pretty
+
+import execute.*
+import specification.*
+import core.{AsExecution, Execution}
+import AsResultProp.{given, *}
+import ScalaCheckProperty.{given, *}
+
+/** A ScalaCheckProperty encapsulates a ScalaCheck Prop and its parameters
+  */
+trait ScalaCheckEffectProperty[F[_]]:
+  type SelfType <: ScalaCheckEffectProperty[F]
+
+  def propF: PropF[F]
+
+  def parameters: Parameters
+
+  def prettyFreqMap: FreqMap[Set[Any]] => Pretty
+
+  def setParameters(ps: Parameters): SelfType
+
+  def setSeed(seed: Seed): SelfType
+
+  def setSeed(seed: String): SelfType
+
+  def setVerbosity(v: Int): SelfType =
+    setParameters(parameters.setVerbosity(v))
+
+  def set(
+      minTestsOk: Int = parameters.minTestsOk,
+      minSize: Int = parameters.minSize,
+      maxDiscardRatio: Float = parameters.maxDiscardRatio,
+      maxSize: Int = parameters.maxSize,
+      workers: Int = parameters.workers,
+      callback: Test.TestCallback = parameters.testCallback,
+      loader: Option[ClassLoader] = parameters.loader
+  ): SelfType =
+    setParameters(
+      parameters.copy(
+        minTestsOk = minTestsOk,
+        minSize = minSize,
+        maxDiscardRatio = maxDiscardRatio,
+        maxSize = maxSize,
+        workers = workers,
+        testCallback = callback,
+        loader = loader
+      )
+    )
+
+  def display(
+      minTestsOk: Int = parameters.minTestsOk,
+      minSize: Int = parameters.minSize,
+      maxDiscardRatio: Float = parameters.maxDiscardRatio,
+      maxSize: Int = parameters.maxSize,
+      workers: Int = parameters.workers,
+      callback: Test.TestCallback = parameters.testCallback,
+      loader: Option[ClassLoader] = parameters.loader
+  ): SelfType =
+    setParameters(
+      parameters
+        .copy(
+          minTestsOk = minTestsOk,
+          minSize = minSize,
+          maxDiscardRatio = maxDiscardRatio,
+          maxSize = maxSize,
+          workers = workers,
+          testCallback = callback,
+          loader = loader
+        )
+        .setVerbosity(1)
+    )
+
+  def verbose: SelfType =
+    setVerbosity(1)
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType
+
+  def prettyFreqMap(f: FreqMap[Set[Any]] => String): SelfType =
+    setPrettyFreqMap((fq: FreqMap[Set[Any]]) => Pretty(_ => f(fq)))
+

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectProperty.scala
@@ -115,31 +115,6 @@ object ScalaCheckEffectProperty:
 trait ScalaCheckEffectFunction[F[_]] extends ScalaCheckEffectProperty[F]:
   def noShrink: SelfType
 
-  def context: Option[Context]
-
-  def setContext(context: Context): SelfType
-
-  def before(action: =>Any): SelfType =
-    setContext(Before.create(action))
-
-  def after(action: =>Any): SelfType =
-    setContext(After.create(action))
-
-  def beforeAfter(beforeAction: =>Any, afterAction: =>Any): SelfType =
-    setContext(BeforeAfter.create(beforeAction, afterAction))
-
-  def around(action: Result => Result): SelfType =
-    setContext(Around.create(action))
-
-  protected def executeInContext[R: AsResult](result: =>R) = {
-    lazy val executed = result
-    context.foreach(_(executed))
-    executed.asInstanceOf[Matchable] match {
-      case p: Prop => p
-      case other   => AsResultProp.asResultToProp.apply(other.asInstanceOf[R])
-    }
-  }
-
 case class ScalaCheckEffectFunction1[F[_]: MonadThrow, T, R](
     execute: T => F[R],
     arbitrary: Arbitrary[T],

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCheck.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCheck.scala
@@ -1,0 +1,143 @@
+package org.specs2
+package scalacheck
+package effect
+
+import cats.MonadThrow
+import cats.syntax.all.*
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.Test
+import org.scalacheck.effect.PropF
+import org.scalacheck.rng.Seed
+import org.scalacheck.util.FreqMap
+import org.scalacheck.util.Pretty
+import org.scalacheck.util.Pretty.*
+
+import scala.util.control.NonFatal
+
+import language.adhocExtensions
+import execute.*
+import matcher.*
+import PrettyDetails.*
+
+trait ScalaCheckEffectPropertyCheck extends ExpectationsCreation:
+
+  /** checks if the property is true for each generated value, and with the specified parameters
+    */
+  def check[F[_]: MonadThrow](
+      prop: PropF[F],
+      parameters: Parameters,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty
+  ): F[Result] =
+
+    val initialSeed = parameters.seed.getOrElse(Seed.random())
+
+    val genParams = Gen.Parameters.default.withInitialSeed(initialSeed)
+
+    prop.check(parameters.testParameters, genParams).map { result =>
+      val prettyTestResult = prettyResult(result, parameters, initialSeed, prettyFreqMap)(parameters.prettyParams)
+      val testResult = if parameters.prettyParams.verbosity == 0 then "" else prettyTestResult
+
+      val checkResult =
+        result match
+          case Test.Result(Test.Passed, succeeded, discarded, fq, _) =>
+            Success(prettyTestResult, testResult, succeeded)
+
+          case Test.Result(Test.Proved(as), succeeded, discarded, fq, _) =>
+            Success(prettyTestResult, testResult, succeeded)
+
+          case Test.Result(Test.Exhausted, n, _, fq, _) =>
+            Failure(prettyTestResult)
+
+          case Test.Result(Test.Failed(args, labels), n, _, fq, _) =>
+            new Failure(prettyTestResult, details = collectDetails(fq)) {
+              // the location is already included in the failure message
+              override def location = ""
+            }
+
+          case Test.Result(Test.PropException(args, ex, labels), n, _, fq, _) =>
+            ex match
+              case FailureException(f) =>
+                // in that case we want to represent a normal failure
+                val failedResult =
+                  prettyResult(result.copy(status = Test.Failed(args, labels)), parameters, initialSeed, prettyFreqMap)(
+                    parameters.prettyParams
+                  )
+                Failure(failedResult + "\n> " + f.message, details = f.details, trace = f.trace)
+
+              case DecoratedResultException(DecoratedResult(_, f)) =>
+                // in that case we want to represent a normal failure
+                val failedResult =
+                  prettyResult(result.copy(status = Test.Failed(args, labels)), parameters, initialSeed, prettyFreqMap)(
+                    parameters.prettyParams
+                  )
+                f.setMessage(failedResult + "\n>\n" + f.message)
+
+              case e: AssertionError =>
+                val failedResult =
+                  prettyResult(result.copy(status = Test.Failed(args, labels)), parameters, initialSeed, prettyFreqMap)(
+                    parameters.prettyParams
+                  )
+                Failure(failedResult + "\n> " + e.getMessage, trace = e.getStackTrace.toList)
+
+              case SkipException(s)    => s
+              case PendingException(p) => p
+              case NonFatal(t)         => Error(prettyTestResult + showCause(t), t)
+
+      checkResultFailure(checkResult)
+
+    }
+
+  /** @return the cause of the exception as a String if there is one */
+  def showCause(t: Throwable) =
+    Option(t.getCause).map(s"\n> caused by " + _).getOrElse("")
+
+  def frequencies(fq: FreqMap[Set[Any]], parameters: Parameters, prettyFreqMap: FreqMap[Set[Any]] => Pretty) =
+    val noCollectedValues = parameters.prettyParams.verbosity <= 0 || fq.getRatios.map(_._1).forall(_.toSet == Set(()))
+    if noCollectedValues then ""
+    else "\n" ++ prettyFreqMap(removeDetails(fq))(parameters.prettyParams)
+
+  /** copied from ScalaCheck to be able to inject the proper freqMap pretty */
+  def prettyResult(
+      res: Test.Result,
+      parameters: Parameters,
+      initialSeed: =>Seed,
+      freqMapPretty: FreqMap[Set[Any]] => Pretty
+  ) = Pretty { prms =>
+
+    def displaySeed: String =
+      if prms.verbosity >= 0 then s"\nThe seed is ${initialSeed.toBase64}\n"
+      else ""
+
+    def labels(ls: scala.collection.immutable.Set[String]) =
+      if ls.isEmpty then ""
+      else s"> Labels of failing property:${ls.mkString("\n")}"
+
+    val s = res.status match
+      case Test.Proved(args) =>
+        s"OK, proved property.${prettyArgs(args)(prms)}" +
+          (if prms.verbosity > 1 then displaySeed else "")
+
+      case Test.Passed =>
+        "OK, passed " + res.succeeded + " tests." +
+          (if prms.verbosity > 1 then displaySeed else "")
+
+      case Test.Failed(args, l) =>
+        s"Falsified after " + res.succeeded + s" passed tests.\n${labels(l)}${prettyArgs(args)(prms)}" +
+          displaySeed
+
+      case Test.Exhausted =>
+        "Gave up after only " + res.succeeded + " passed tests. " + res.discarded + " tests were discarded." +
+          displaySeed
+
+      case Test.PropException(args, e, l) =>
+        s"Exception raised on property evaluation.${labels(l)}${prettyArgs(args)(prms)}> Exception: " + pretty(
+          e,
+          prms
+        ) +
+          displaySeed
+    val t = if prms.verbosity <= 1 then "" else "Elapsed time: " + prettyTime(res.time)
+    val map = freqMapPretty(res.freqMap).apply(prms)
+    s"$s$t$map"
+  }

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCreation.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCreation.scala
@@ -54,3 +54,219 @@ trait ScalaCheckEffectPropertyCreation:
       context = None,
       parameters
     )
+
+  /** create a ScalaCheck property from a function of 3 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, R](result: (T1, T2, T3) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction3[F, T1, T2, T3, R] =
+    ScalaCheckEffectFunction3(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 4 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, T4, R](result: (T1, T2, T3, T4) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      arbitrary4: Arbitrary[T4],
+      shrink4: Shrink[T4],
+      pretty4: T4 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction4[F, T1, T2, T3, T4, R] =
+    ScalaCheckEffectFunction4(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      ScalaCheckArgInstances(arbitrary4, Some(shrink4), collectors = Nil, pretty = pretty4),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 5 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, T4, T5, R](result: (T1, T2, T3, T4, T5) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      arbitrary4: Arbitrary[T4],
+      shrink4: Shrink[T4],
+      pretty4: T4 => Pretty,
+      arbitrary5: Arbitrary[T5],
+      shrink5: Shrink[T5],
+      pretty5: T5 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction5[F, T1, T2, T3, T4, T5, R] =
+    ScalaCheckEffectFunction5(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      ScalaCheckArgInstances(arbitrary4, Some(shrink4), collectors = Nil, pretty = pretty4),
+      ScalaCheckArgInstances(arbitrary5, Some(shrink5), collectors = Nil, pretty = pretty5),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 6 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, R](result: (T1, T2, T3, T4, T5, T6) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      arbitrary4: Arbitrary[T4],
+      shrink4: Shrink[T4],
+      pretty4: T4 => Pretty,
+      arbitrary5: Arbitrary[T5],
+      shrink5: Shrink[T5],
+      pretty5: T5 => Pretty,
+      arbitrary6: Arbitrary[T6],
+      shrink6: Shrink[T6],
+      pretty6: T6 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction6[F, T1, T2, T3, T4, T5, T6, R] =
+    ScalaCheckEffectFunction6(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      ScalaCheckArgInstances(arbitrary4, Some(shrink4), collectors = Nil, pretty = pretty4),
+      ScalaCheckArgInstances(arbitrary5, Some(shrink5), collectors = Nil, pretty = pretty5),
+      ScalaCheckArgInstances(arbitrary6, Some(shrink6), collectors = Nil, pretty = pretty6),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 7 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, T7, R](result: (T1, T2, T3, T4, T5, T6, T7) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      arbitrary4: Arbitrary[T4],
+      shrink4: Shrink[T4],
+      pretty4: T4 => Pretty,
+      arbitrary5: Arbitrary[T5],
+      shrink5: Shrink[T5],
+      pretty5: T5 => Pretty,
+      arbitrary6: Arbitrary[T6],
+      shrink6: Shrink[T6],
+      pretty6: T6 => Pretty,
+      arbitrary7: Arbitrary[T7],
+      shrink7: Shrink[T7],
+      pretty7: T7 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction7[F, T1, T2, T3, T4, T5, T6, T7, R] =
+    ScalaCheckEffectFunction7(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      ScalaCheckArgInstances(arbitrary4, Some(shrink4), collectors = Nil, pretty = pretty4),
+      ScalaCheckArgInstances(arbitrary5, Some(shrink5), collectors = Nil, pretty = pretty5),
+      ScalaCheckArgInstances(arbitrary6, Some(shrink6), collectors = Nil, pretty = pretty6),
+      ScalaCheckArgInstances(arbitrary7, Some(shrink7), collectors = Nil, pretty = pretty7),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 8 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, T3, T4, T5, T6, T7, T8, R](result: (T1, T2, T3, T4, T5, T6, T7, T8) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      arbitrary3: Arbitrary[T3],
+      shrink3: Shrink[T3],
+      pretty3: T3 => Pretty,
+      arbitrary4: Arbitrary[T4],
+      shrink4: Shrink[T4],
+      pretty4: T4 => Pretty,
+      arbitrary5: Arbitrary[T5],
+      shrink5: Shrink[T5],
+      pretty5: T5 => Pretty,
+      arbitrary6: Arbitrary[T6],
+      shrink6: Shrink[T6],
+      pretty6: T6 => Pretty,
+      arbitrary7: Arbitrary[T7],
+      shrink7: Shrink[T7],
+      pretty7: T7 => Pretty,
+      arbitrary8: Arbitrary[T8],
+      shrink8: Shrink[T8],
+      pretty8: T8 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction8[F, T1, T2, T3, T4, T5, T6, T7, T8, R] =
+    ScalaCheckEffectFunction8(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      ScalaCheckArgInstances(arbitrary3, Some(shrink3), collectors = Nil, pretty = pretty3),
+      ScalaCheckArgInstances(arbitrary4, Some(shrink4), collectors = Nil, pretty = pretty4),
+      ScalaCheckArgInstances(arbitrary5, Some(shrink5), collectors = Nil, pretty = pretty5),
+      ScalaCheckArgInstances(arbitrary6, Some(shrink6), collectors = Nil, pretty = pretty6),
+      ScalaCheckArgInstances(arbitrary7, Some(shrink7), collectors = Nil, pretty = pretty7),
+      ScalaCheckArgInstances(arbitrary8, Some(shrink8), collectors = Nil, pretty = pretty8),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCreation.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCreation.scala
@@ -1,0 +1,56 @@
+package org.specs2
+package scalacheck
+package effect
+
+import cats.MonadThrow
+import org.scalacheck.*
+import org.scalacheck.util.FreqMap
+import org.scalacheck.util.Pretty
+
+import execute.AsResult
+import ScalaCheckEffectProperty.*
+
+trait ScalaCheckEffectPropertyCreation:
+
+  /** create a ScalaCheck property from a function */
+  def propF[F[_]: MonadThrow, T, R](result: T => F[R])(implicit
+      arbitrary: Arbitrary[T],
+      shrink: Shrink[T],
+      pretty: T => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction1[F, T, R] =
+    ScalaCheckEffectFunction1(
+      result,
+      arbitrary,
+      Some(shrink),
+      collectors = Nil,
+      pretty,
+      prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )
+
+  /** create a ScalaCheck property from a function of 2 arguments */
+  def propF[F[_]: MonadThrow, T1, T2, R](result: (T1, T2) => F[R])(using
+      arbitrary1: Arbitrary[T1],
+      shrink1: Shrink[T1],
+      pretty1: T1 => Pretty,
+      arbitrary2: Arbitrary[T2],
+      shrink2: Shrink[T2],
+      pretty2: T2 => Pretty,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty,
+      asResult: AsResult[R],
+      parameters: Parameters
+  ): ScalaCheckEffectFunction2[F, T1, T2, R] =
+    ScalaCheckEffectFunction2(
+      result,
+      ScalaCheckArgInstances(arbitrary1, Some(shrink1), collectors = Nil, pretty = pretty1),
+      ScalaCheckArgInstances(arbitrary2, Some(shrink2), collectors = Nil, pretty = pretty2),
+      prettyFreqMap = prettyFreqMap,
+      asResult,
+      context = None,
+      parameters
+    )

--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyDsl.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyDsl.scala
@@ -1,0 +1,39 @@
+package org.specs2
+package scalacheck
+package effect
+
+import org.scalacheck.Prop
+import org.scalacheck.Properties
+import org.scalacheck.effect.PropF
+import org.scalacheck.rng.Seed
+import org.scalacheck.util.*
+import org.specs2.specification.core.Fragments
+import org.specs2.specification.create.FragmentsFactory
+
+trait ScalaCheckEffectPropertyDsl extends FragmentsFactory with AsResultPropF:
+
+  given propFToScalaCheckProperty[F[_]](using
+      parameters: Parameters,
+      prettyFreqMap: FreqMap[Set[Any]] => Pretty
+  ): Conversion[PropF[F], ScalaCheckEffectProp[F]] with
+    def apply(propF: PropF[F]): ScalaCheckEffectProp[F] =
+      ScalaCheckEffectProp(propF, parameters, prettyFreqMap)
+
+case class ScalaCheckEffectProp[F[_]](
+    propF: PropF[F],
+    parameters: Parameters,
+    prettyFreqMap: FreqMap[Set[Any]] => Pretty
+) extends ScalaCheckEffectProperty[F]:
+  type SelfType = ScalaCheckEffectProp[F]
+
+  def setParameters(ps: Parameters): SelfType =
+    copy(parameters = ps)
+
+  def setSeed(seed: Seed): SelfType =
+    copy(parameters = parameters.copy(seed = Some(seed)))
+
+  def setSeed(seed: String): SelfType =
+    copy(parameters = parameters.copy(seed = Parameters.makeSeed(seed)))
+
+  def setPrettyFreqMap(f: FreqMap[Set[Any]] => Pretty): SelfType =
+    copy(prettyFreqMap = f)

--- a/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
+++ b/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
@@ -17,7 +17,7 @@ class ScalaCheckEffectMatchersApiSpec extends Specification, ScalaCheckEffect, I
  A ScalaCheck property can be used in the body of an Example
  ${forAllF { (i: Int) => IO(i > 0 || i <= 0) }}
 
- The `prop` method can be used to create a property from a function
+ The `propF` method can be used to create a property from a function
     returning a result
     ${propF { (i: Int) => IO(success) }}
     returning a match result

--- a/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
+++ b/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
@@ -4,9 +4,9 @@ package scalacheck.effect
 import _root_.cats.effect.IO
 import org.scalacheck.Prop.*
 import org.scalacheck.effect.PropF.*
-import org.scalacheck.Prop.propBoolean
 import org.scalacheck.util.{FreqMap, Pretty}
 import org.scalacheck.*
+import org.scalacheck.effect.*
 import org.specs2.cats.effect.IOExecution
 import org.specs2.Specification
 
@@ -79,17 +79,17 @@ class ScalaCheckEffectMatchersApiSpec extends Specification, ScalaCheckEffect, I
 
  Test parameters can also be specified
    the minimum number of ok tests
-   minTestsOk1
+   $minTestsOk1
 
    the verbosity of a property can be turned on and off
-   verbose1
+   $verbose1
 
   """
-  // def minTestsOk1: Prop =
-  //   propF { (i: Int) => propBoolean(i > 0) ==> (i > 0) }.set(minTestsOk = 50)
+  def minTestsOk1 =
+    propF { (i: Int) => IO(i === i) }.set(minTestsOk = 50)
 
-  // def verbose1: Prop =
-  //   propF { (i: Int) => propBoolean(i > 0) ==> (i > 0) }.verbose
+  def verbose1 =
+    propF { (i: Int) => IO(i === i) }.verbose
 
   val positiveInts = Arbitrary(Gen.choose(1, 5))
 

--- a/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
+++ b/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
@@ -26,12 +26,6 @@ class ScalaCheckEffectMatchersApiSpec extends Specification, ScalaCheckEffect, I
     ${propF { (i: Int) => IO(i > 0 || i <= 0) }}
     using  an implication and a match result
 
-    // propBoolean is used - can be removed when scalacheck 1.15.0 is out
-    {prop { (i: Int) => propBoolean(i > 0) ==> (i must be_>(0)) }}
-    {prop { (i: Int, j: Int) => propBoolean(i > j) ==> (i must be_>(j)) }}
-    using an implication and a boolean value
-    {prop { (i: Int) => propBoolean(i > 0) ==> (i > 0) }}
-
  It is possible to specify typeclass instances for Arbitrary, Shrink, Pretty and collect
    Arbitrary
    to specify a specific arbitrary instance for a parameter

--- a/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
+++ b/scalacheck-effect/src/test/scala/org/specs2/scalacheck/effect/ScalaCheckEffectMatchersApiSpec.scala
@@ -1,0 +1,105 @@
+package org.specs2
+package scalacheck.effect
+
+import _root_.cats.effect.IO
+import org.scalacheck.Prop.*
+import org.scalacheck.effect.PropF.*
+import org.scalacheck.Prop.propBoolean
+import org.scalacheck.util.{FreqMap, Pretty}
+import org.scalacheck.*
+import org.specs2.cats.effect.IOExecution
+import org.specs2.Specification
+
+class ScalaCheckEffectMatchersApiSpec extends Specification, ScalaCheckEffect, IOExecution:
+  def is = s2"""
+ There are various ways to use a property in specs2
+
+ A ScalaCheck property can be used in the body of an Example
+ ${forAllF { (i: Int) => IO(i > 0 || i <= 0) }}
+
+ The `prop` method can be used to create a property from a function
+    returning a result
+    ${propF { (i: Int) => IO(success) }}
+    returning a match result
+    ${propF { (i: Int) => IO(i must (be_>(0) or be_<=(0))) }}
+    returning a boolean value
+    ${propF { (i: Int) => IO(i > 0 || i <= 0) }}
+    using  an implication and a match result
+
+    // propBoolean is used - can be removed when scalacheck 1.15.0 is out
+    {prop { (i: Int) => propBoolean(i > 0) ==> (i must be_>(0)) }}
+    {prop { (i: Int, j: Int) => propBoolean(i > j) ==> (i must be_>(j)) }}
+    using an implication and a boolean value
+    {prop { (i: Int) => propBoolean(i > 0) ==> (i > 0) }}
+
+ It is possible to specify typeclass instances for Arbitrary, Shrink, Pretty and collect
+   Arbitrary
+   to specify a specific arbitrary instance for a parameter
+   ${propF { (i: Int) => IO(i must be_>(0)) }.setArbitrary(positiveInts)}
+   to specify a specific arbitrary instance for any parameter
+   ${propF { (s: String, j: Int) => IO(j must be_>(0)) }.setArbitrary2(positiveInts)}
+   to specify all the arbitrary instances
+   ${propF { (i: Int, j: Int) => IO(i + j must be_>(0)) }.setArbitraries(positiveInts, positiveInts)}
+
+   Gen
+   to specify a specific generator for a parameter
+   ${propF { (i: Int) => IO(i must be_>(0)) }.setGen(positiveInts.arbitrary)}
+   to specify a specific generator for any parameter
+   ${propF { (s: String, j: Int) => IO(j must be_>(0)) }.setGen2(positiveInts.arbitrary)}
+   to specify all the generators
+   ${propF { (i: Int, j: Int) => IO(i + j must be_>(0)) }.setGens(positiveInts.arbitrary, positiveInts.arbitrary)}
+
+   Shrink
+   to specify a specific shrink instance for a parameter
+   ${propF { (i: Int) => IO(i === i) }.setShrink(shrinkInts)}
+   to specify a specific shrink instance for any parameter
+   ${propF { (s: String, j: Int) => IO(true) }.setShrink2(shrinkInts)}
+   to specify all the shrink instances
+   ${propF { (i: Int, j: Int) => IO(i === i) }.setShrinks(shrinkInts, shrinkInts)}
+
+   Pretty
+   to specify a specific pretty instance for a parameter
+   ${propF { (i: Int) => IO(i === i) }.setPretty(prettyInts)}
+   ${propF { (i: Int) => IO(i === i) }.pretty(_.toString)}
+   to specify a specific pretty instance for any parameter
+   ${propF { (s: String, j: Int) => IO(true) }.setPretty2(prettyInts)}
+   ${propF { (s: String, j: Int) => IO(true) }.pretty2(_.toString)}
+   to specify all the pretty instances
+   ${propF { (i: String, j: Int) => IO(i === i) }.setPretties(prettyStrings, prettyInts)}
+   ${propF { (i: String, j: Int) => IO(i === i) }.pretties(_.toString, _.toString)}
+   to specify the pretty for collected data
+   ${propF { (i: String, j: Int) => IO(i === i) }.collectAll
+    .prettyFreqMap((fq: FreqMap[Set[Any]]) => fq.total.toString)}
+   ${propF { (i: String, j: Int) => IO(i === i) }.collectAll.prettyFreqMap(_.toString)}
+
+   Collect
+   to specify a specific collect function for a parameter
+   ${propF { (i: Int) => IO(i === i) }.collect}
+   ${propF { (i: Int) => IO(i === i) }.collectArg((i: Int) => math.abs(i))}
+   to specify a specific collect function for any parameter
+   ${propF { (s: String, j: Int) => IO(true) }.collect2}
+   ${propF { (s: String, j: Int) => IO(true) }.collectArg2(math.abs)}
+   to specify all the collect functions
+   ${propF { (i: Int, j: Int) => IO(i === i) }.collectAll}
+   ${propF { (i: Int, j: Int) => IO(i === i) }.collectAllArgs(math.abs, math.abs)}
+
+ Test parameters can also be specified
+   the minimum number of ok tests
+   minTestsOk1
+
+   the verbosity of a property can be turned on and off
+   verbose1
+
+  """
+  // def minTestsOk1: Prop =
+  //   propF { (i: Int) => propBoolean(i > 0) ==> (i > 0) }.set(minTestsOk = 50)
+
+  // def verbose1: Prop =
+  //   propF { (i: Int) => propBoolean(i > 0) ==> (i > 0) }.verbose
+
+  val positiveInts = Arbitrary(Gen.choose(1, 5))
+
+  val shrinkInts = Shrink.shrinkAny[Int]
+
+  val prettyInts = (i: Int) => Pretty(_ => i.toString)
+  val prettyStrings = (s: String) => Pretty(_ => s)


### PR DESCRIPTION
This takes the first steps towards https://github.com/etorreborre/specs2-cats/issues/2 to support ScalaCheck Effect.

@etorreborre as you said, this is no small thing :) so I want to pause and get feedback on my strategy before proceeding. I'm heavily basing this on the ScalaCheck module in specs2, replacing `Prop` -> `PropF`. So far I've ported what I think are the "core" components:
- `ScalaCheckEffectPropertyCheck`
- `ScalaCheckEffectProperty`
- `AsResultPropF`

The biggest difference is the use of `AsExecution` instead of `AsResult`, which is implemented in terms of a given `AsExecution[F[Result]]` (which is, for example, provided for `IO` in the specs2-cats-effect module).

IIUC, with these it should be possible to implement the 1..8 `ScalaCheckEffectFunction`s and `propF` methods.

Thanks in advance for your feedback and advice :)