### PR TITLE
Inherit some methods directly from ScalaCheck

### DIFF
--- a/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCheck.scala
+++ b/scalacheck-effect/src/main/scala/org/specs2/scalacheck/effect/ScalaCheckEffectPropertyCheck.scala
@@ -21,7 +21,7 @@ import execute.*
 import matcher.*
 import PrettyDetails.*
 
-trait ScalaCheckEffectPropertyCheck extends ExpectationsCreation:
+trait ScalaCheckEffectPropertyCheck extends ScalaCheckPropertyCheck:
 
   /** checks if the property is true for each generated value, and with the specified parameters
     */
@@ -88,56 +88,3 @@ trait ScalaCheckEffectPropertyCheck extends ExpectationsCreation:
       checkResultFailure(checkResult)
 
     }
-
-  /** @return the cause of the exception as a String if there is one */
-  def showCause(t: Throwable) =
-    Option(t.getCause).map(s"\n> caused by " + _).getOrElse("")
-
-  def frequencies(fq: FreqMap[Set[Any]], parameters: Parameters, prettyFreqMap: FreqMap[Set[Any]] => Pretty) =
-    val noCollectedValues = parameters.prettyParams.verbosity <= 0 || fq.getRatios.map(_._1).forall(_.toSet == Set(()))
-    if noCollectedValues then ""
-    else "\n" ++ prettyFreqMap(removeDetails(fq))(parameters.prettyParams)
-
-  /** copied from ScalaCheck to be able to inject the proper freqMap pretty */
-  def prettyResult(
-      res: Test.Result,
-      parameters: Parameters,
-      initialSeed: =>Seed,
-      freqMapPretty: FreqMap[Set[Any]] => Pretty
-  ) = Pretty { prms =>
-
-    def displaySeed: String =
-      if prms.verbosity >= 0 then s"\nThe seed is ${initialSeed.toBase64}\n"
-      else ""
-
-    def labels(ls: scala.collection.immutable.Set[String]) =
-      if ls.isEmpty then ""
-      else s"> Labels of failing property:${ls.mkString("\n")}"
-
-    val s = res.status match
-      case Test.Proved(args) =>
-        s"OK, proved property.${prettyArgs(args)(prms)}" +
-          (if prms.verbosity > 1 then displaySeed else "")
-
-      case Test.Passed =>
-        "OK, passed " + res.succeeded + " tests." +
-          (if prms.verbosity > 1 then displaySeed else "")
-
-      case Test.Failed(args, l) =>
-        s"Falsified after " + res.succeeded + s" passed tests.\n${labels(l)}${prettyArgs(args)(prms)}" +
-          displaySeed
-
-      case Test.Exhausted =>
-        "Gave up after only " + res.succeeded + " passed tests. " + res.discarded + " tests were discarded." +
-          displaySeed
-
-      case Test.PropException(args, e, l) =>
-        s"Exception raised on property evaluation.${labels(l)}${prettyArgs(args)(prms)}> Exception: " + pretty(
-          e,
-          prms
-        ) +
-          displaySeed
-    val t = if prms.verbosity <= 1 then "" else "Elapsed time: " + prettyTime(res.time)
-    val map = freqMapPretty(res.freqMap).apply(prms)
-    s"$s$t$map"
-  }


### PR DESCRIPTION
I ran into troubles in a spec using both `Discipline` and `ScalaCheckEffect` because of these duplicate definitions.