### PR TITLE
Time-mocking IO execution with TestControl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,10 @@ val catsDependencies = libraryDependencies ++= Seq(
   "org.specs2" %%% "specs2-core" % Specs2Version,
   "org.typelevel" %%% "cats-core" % "2.7.0"
 )
-val catsEffectDependencies = libraryDependencies += "org.typelevel" %%% "cats-effect" % "3.3.8"
+val catsEffectDependencies = libraryDependencies ++= Seq(
+  "org.typelevel" %%% "cats-effect" % "3.3.8",
+  "org.typelevel" %%% "cats-effect-testkit" % "3.3.8"
+)
 val scalacheckEffectDependencies = libraryDependencies ++= Seq(
   "org.specs2" %%% "specs2-scalacheck" % Specs2Version,
   "org.typelevel" %%% "scalacheck-effect" % "1.0.3"

--- a/cats-effect/src/main/scala/org/specs2/cats/effect/TestControlIOExecution.scala
+++ b/cats-effect/src/main/scala/org/specs2/cats/effect/TestControlIOExecution.scala
@@ -1,0 +1,11 @@
+package org.specs2.cats.effect
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.{AsExecution, Execution}
+
+trait TestControlIOExecution extends IOExecution:
+  given testControlExecution[T: AsResult]: AsExecution[IO[T]] with
+    def execute(io: =>IO[T]): Execution =
+      given_AsExecution_IO[T].execute(TestControl.executeEmbed(io))

--- a/cats-effect/src/test/scala/org/specs2/cats/effect/IOMatchersSpec.scala
+++ b/cats-effect/src/test/scala/org/specs2/cats/effect/IOMatchersSpec.scala
@@ -3,6 +3,8 @@ package org.specs2.cats.effect
 import cats.effect.*
 import org.specs2.Specification
 import org.specs2.concurrent.*
+import org.specs2.matcher.ValueChecks
+import org.specs2.specification.core.Execution
 
 import scala.concurrent.duration.*
 
@@ -28,3 +30,12 @@ class IOMatchersSpec extends Specification with IOMatchers with IOExecution:
   def matcher5 = IO.canceled must beCanceled
 
   def result1 = IO("ok" === "ok")
+
+class IOTestControlSpec extends Specification with ValueChecks with TestControlIOExecution:
+
+  def fakeSleepExecution = (IO.sleep(10.days).as(1 === 1): Execution).setTimeout(10.seconds)
+
+  def is = s2"""
+    An IO test runs in mock time with TestControlIOExecution
+    $fakeSleepExecution
+  """


### PR DESCRIPTION
This allows to simply tests executions that does sleeping